### PR TITLE
Correct #11 for the future releases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Simply open userChrome.css in a text editor and change the values at the top of 
 
 
 ## How to install
-1. [Download](https://github.com/coekuss/quietfox/releases/download/v6/quietfox76.zip) and unzip
+1. [Download](https://github.com/coekuss/quietfox/releases/latest) and unzip
 2. Go to `about:support` in Firefox and open your Profile Folder
 3. Drop your unzipped "chrome" folder into the folder that appears
 4. Go to `about:config` in your Firefox and set the value of `toolkit.legacyUserProfileCustomizations.stylesheets` to `true` (this enables the loading of userChrome mods)


### PR DESCRIPTION
GitHub has a URL redirect function, to download the latest released versions of a repo, from one link. https://help.github.com/en/github/administering-a-repository/linking-to-releases
As long, as you do ¨beta/aplha/nightly¨ releases, in which you don’t want all users to opt-in, you should be good.
HOWEVER, If you want that link to be a direct download link, You will have to change the name of the future releases of the same name (like, quietfox.zip instead of quietfox[releasenumber].zip). In that case, replace that link to https://github.com/coekuss/quietfox/releases/latest/download/NAMEOFTHEFUTURERELEASESWITHTHESAMENAME.zip. 
(If you want to try it out, for the quietfox76 version, the link would be https://github.com/coekuss/quietfox/releases/latest/download/quietfox76.zip)